### PR TITLE
Add Ability to Run Doc test

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,14 @@
       {
         "command": "cargo-runner.doc-test",
         "title": "Doc Test"
+      },
+      {
+        "command": "cargo-runner.test-doc-attr",
+        "title": "Doc Test Attr"
+      },
+      {
+        "command": "cargo-runner.test-multiline-doc",
+        "title": "Doc multiline Test"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
       {
         "command": "cargo-runner.exec",
         "title": "Cargo Runner"
+      },
+      {
+        "command": "cargo-runner.doc-test",
+        "title": "Doc Test"
       }
     ],
     "keybindings": [

--- a/src/extension-debugger.bak
+++ b/src/extension-debugger.bak
@@ -8,6 +8,9 @@ import { getPackage } from './get_package';
 import { getTestName } from './get_test_name';
 import { tests } from './tests';
 import { exec } from './exec';
+import handleDocAttribute from './handle_doc_attribute';
+import handleDocTest from './handle_doc_test';
+import handleMultilineDocTest from './handle_multiline_docs';
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -119,6 +122,65 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.window.showInformationMessage(`Is Workspace: ${isWorkspace}`);
 	}
 	));
+
+	// create subscription for getTestName
+	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.test-doc-attr', async () => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			vscode.window.showInformationMessage('Open a document to test');
+			return;
+		}
+
+		const document = editor.document;
+		const position = editor.selection.active;
+
+		const result = await handleDocAttribute(document, position);
+
+		if (result) {
+			vscode.window.showInformationMessage(`Doc attribute valid: ${result.isValid}, Function name: ${result.fnName}`);
+		} else {
+			vscode.window.showInformationMessage('Not in a doc attribute scope');
+		}
+	}
+	));
+
+	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.test-multiline-doc', async () => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			vscode.window.showInformationMessage('Open a document to test');
+			return;
+		}
+
+		const document = editor.document;
+		const position = editor.selection.active;
+
+		const result = await handleMultilineDocTest(document, position);
+
+		if (result) {
+			vscode.window.showInformationMessage(`Doc attribute valid: ${result.isValid}, Function name: ${result.fnName}`);
+		} else {
+			vscode.window.showInformationMessage('Not in Multiline Doc Scope');
+		}
+	}
+	));
+	
+	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.doc-test', async () => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			vscode.window.showInformationMessage('Open a document to test');
+			return;
+		}
+		const document = editor.document;
+		const position = editor.selection.active;
+
+		const result = await handleDocTest(document, position);
+
+		if (result) {
+			vscode.window.showInformationMessage(`Doc attribute valid: ${result.isValid}, Function name: ${result.fnName}`);
+		} else {
+			vscode.window.showInformationMessage('Not in a doc attribute scope');
+		}
+	}));
 }
 
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import exec from './exec';
+import isDocTest from './is_doctest';
 
 export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.exec', async () => {
@@ -18,6 +19,17 @@ export function activate(context: vscode.ExtensionContext) {
 			terminal.show();
 		} else {
 			vscode.window.showInformationMessage('Cannot run.');
+		}
+	}));
+	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.doc-test', async () => {
+		const activeEditor = vscode.window.activeTextEditor;
+		if (activeEditor) {
+			const filePath = activeEditor.document.uri.path;
+			const position = vscode.window.activeTextEditor?.selection.active;
+
+			
+			const result = await isDocTest(filePath, position);
+			vscode.window.showInformationMessage(`Is on doc-test: ${result}`);
 		}
 	}));
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,5 @@
 import * as vscode from 'vscode';
 import exec from './exec';
-import handleDocAttribute from './handle_doc_attribute';
-import handleDocTest from './handle_doc_test';
-import handleMultilineDocTest from './handle_multiline_docs';
-
 
 export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.exec', async () => {
@@ -24,64 +20,4 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.window.showInformationMessage('Cannot run.');
 		}
 	}));
-	// create subscription for getTestName
-	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.test-doc-attr', async () => {
-		const editor = vscode.window.activeTextEditor;
-		if (!editor) {
-			vscode.window.showInformationMessage('Open a document to test');
-			return;
-		}
-
-		const document = editor.document;
-		const position = editor.selection.active;
-
-		const result = await handleDocAttribute(document, position);
-
-		if (result) {
-			vscode.window.showInformationMessage(`Doc attribute valid: ${result.isValid}, Function name: ${result.fnName}`);
-		} else {
-			vscode.window.showInformationMessage('Not in a doc attribute scope');
-		}
-	}
-	));
-
-	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.test-multiline-doc', async () => {
-		const editor = vscode.window.activeTextEditor;
-		if (!editor) {
-			vscode.window.showInformationMessage('Open a document to test');
-			return;
-		}
-
-		const document = editor.document;
-		const position = editor.selection.active;
-
-		const result = await handleMultilineDocTest(document, position);
-
-		if (result) {
-			vscode.window.showInformationMessage(`Doc attribute valid: ${result.isValid}, Function name: ${result.fnName}`);
-		} else {
-			vscode.window.showInformationMessage('Not in Multiline Doc Scope');
-		}
-	}
-	));
-
-	
-	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.doc-test', async () => {
-		const editor = vscode.window.activeTextEditor;
-		if (!editor) {
-			vscode.window.showInformationMessage('Open a document to test');
-			return;
-		}
-		const document = editor.document;
-		const position = editor.selection.active;
-
-		const result = await handleDocTest(document, position);
-
-		if (result) {
-			vscode.window.showInformationMessage(`Doc attribute valid: ${result.isValid}, Function name: ${result.fnName}`);
-		} else {
-			vscode.window.showInformationMessage('Not in a doc attribute scope');
-		}
-	}));
-
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,9 +27,10 @@ export function activate(context: vscode.ExtensionContext) {
 			const filePath = activeEditor.document.uri.path;
 			const position = vscode.window.activeTextEditor?.selection.active;
 
-			
-			const result = await isDocTest(filePath, position);
-			vscode.window.showInformationMessage(`Is on doc-test: ${result}`);
+
+			const {  isValid, fnName } = await isDocTest(filePath, position);
+			vscode.window.showInformationMessage(`Is on doc-test: ${isValid}, function name: ${fnName}`);
+
 		}
 	}));
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,8 +2,7 @@ import * as vscode from 'vscode';
 import exec from './exec';
 import handleDocAttribute from './handle_doc_attribute';
 import handleDocTest from './handle_doc_test';
-import handleOptimizedDocTest from './handle_multiline_docs';
-
+import handleMultilineDocTest from './handle_multiline_docs';
 
 
 export function activate(context: vscode.ExtensionContext) {
@@ -56,7 +55,7 @@ export function activate(context: vscode.ExtensionContext) {
 		const document = editor.document;
 		const position = editor.selection.active;
 
-		const result = await handleOptimizedDocTest(document, position);
+		const result = await handleMultilineDocTest(document, position);
 
 		if (result) {
 			vscode.window.showInformationMessage(`Doc attribute valid: ${result.isValid}, Function name: ${result.fnName}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,10 @@
 import * as vscode from 'vscode';
 import exec from './exec';
-import isDocTest from './is_doctest';
+import handleDocAttribute from './handle_doc_attribute';
+import handleDocTest from './handle_doc_test';
+import handleOptimizedDocTest from './handle_multiline_docs';
+
+
 
 export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.exec', async () => {
@@ -21,16 +25,63 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.window.showInformationMessage('Cannot run.');
 		}
 	}));
+	// create subscription for getTestName
+	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.test-doc-attr', async () => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			vscode.window.showInformationMessage('Open a document to test');
+			return;
+		}
+
+		const document = editor.document;
+		const position = editor.selection.active;
+
+		const result = await handleDocAttribute(document, position);
+
+		if (result) {
+			vscode.window.showInformationMessage(`Doc attribute valid: ${result.isValid}, Function name: ${result.fnName}`);
+		} else {
+			vscode.window.showInformationMessage('Not in a doc attribute scope');
+		}
+	}
+	));
+
+	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.test-multiline-doc', async () => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			vscode.window.showInformationMessage('Open a document to test');
+			return;
+		}
+
+		const document = editor.document;
+		const position = editor.selection.active;
+
+		const result = await handleOptimizedDocTest(document, position);
+
+		if (result) {
+			vscode.window.showInformationMessage(`Doc attribute valid: ${result.isValid}, Function name: ${result.fnName}`);
+		} else {
+			vscode.window.showInformationMessage('Not in Multiline Doc Scope');
+		}
+	}
+	));
+
+	
 	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.doc-test', async () => {
-		const activeEditor = vscode.window.activeTextEditor;
-		if (activeEditor) {
-			const filePath = activeEditor.document.uri.path;
-			const position = vscode.window.activeTextEditor?.selection.active;
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			vscode.window.showInformationMessage('Open a document to test');
+			return;
+		}
+		const document = editor.document;
+		const position = editor.selection.active;
 
+		const result = await handleDocTest(document, position);
 
-			const {  isValid, fnName } = await isDocTest(filePath, position);
-			vscode.window.showInformationMessage(`Is on doc-test: ${isValid}, function name: ${fnName}`);
-
+		if (result) {
+			vscode.window.showInformationMessage(`Doc attribute valid: ${result.isValid}, Function name: ${result.fnName}`);
+		} else {
+			vscode.window.showInformationMessage('Not in a doc attribute scope');
 		}
 	}));
 

--- a/src/handle_doc_attribute.ts
+++ b/src/handle_doc_attribute.ts
@@ -1,0 +1,84 @@
+import * as vscode from 'vscode';
+
+async function handleDocAttribute(document: vscode.TextDocument, position: vscode.Position): Promise<{ isValid: boolean, fnName: string | null } | null> {
+    let foundDocComment = false;
+    let docCommentStart: number | null = null;
+    let functionStart: number | null = null;
+    let functionEnd: number | null = null;
+    let braceCount = 0;
+    let inFunction = false;
+    let functionName: string | null = null;
+    let inMultiLineDocComment = false;
+
+    for (let i = position.line; i >= 0; i--) {
+        const line = document.lineAt(i).text.trim();
+
+        // Handling for multiline doc comments
+        if ((line.startsWith('#[doc = r#"') || line.startsWith('#[doc = "')) && !foundDocComment) {
+            foundDocComment = true;
+            docCommentStart = i;
+            inMultiLineDocComment = true;
+        }
+
+        if (inMultiLineDocComment && line.endsWith('"#]')) {
+            inMultiLineDocComment = false;
+        }
+
+        // Handling for single-line doc comments
+        if (line.startsWith('#![doc(') && !foundDocComment) {
+            foundDocComment = true;
+            docCommentStart = i;
+        }
+
+        if (!inFunction && !inMultiLineDocComment) {
+            const match = line.match(/(async\s+)?fn\s+(\w+)\s*\(/);
+            if (match) {
+                functionStart = i;
+                functionName = match[2];
+                inFunction = true;
+            }
+        }
+
+        if ((foundDocComment && !inMultiLineDocComment) || inFunction) {
+            break;
+        }
+    }
+
+    if (foundDocComment && docCommentStart !== null && !functionName) {
+        for (let i = docCommentStart + 1; i < document.lineCount; i++) {
+            const line = document.lineAt(i).text.trim();
+
+            const match = line.match(/(async\s+)?fn\s+(\w+)\s*\(/);
+            if (match) {
+                functionStart = i;
+                functionName = match[2];
+                break;
+            }
+        }
+    }
+
+    if (functionStart !== null) {
+        for (let i = functionStart; i < document.lineCount; i++) {
+            const line = document.lineAt(i).text;
+
+            if (line.includes('{')) {
+                braceCount++;
+            }
+            if (line.includes('}')) {
+                braceCount--;
+                if (braceCount === 0) {
+                    functionEnd = i;
+                    break;
+                }
+            }
+        }
+    }
+
+    const inDocComment = foundDocComment && docCommentStart !== null && position.line >= docCommentStart;
+    const inFunctionBody = functionStart !== null && functionEnd !== null && position.line >= functionStart && position.line <= functionEnd;
+    const isValid = inDocComment || inFunctionBody;
+
+    return isValid ? { isValid, fnName: functionName } : null;
+}
+
+export default handleDocAttribute;

--- a/src/handle_doc_attribute.ts
+++ b/src/handle_doc_attribute.ts
@@ -5,15 +5,14 @@ async function handleDocAttribute(document: vscode.TextDocument, position: vscod
     let docCommentStart: number | null = null;
     let functionStart: number | null = null;
     let functionEnd: number | null = null;
-    let braceCount = 0;
-    let inFunction = false;
     let functionName: string | null = null;
     let inMultiLineDocComment = false;
 
+    // Scan upwards from the position to find a doc comment or function start
     for (let i = position.line; i >= 0; i--) {
         const line = document.lineAt(i).text.trim();
 
-        // Handling for multiline doc comments
+        // Handle multiline doc comments
         if ((line.startsWith('#[doc = r#"') || line.startsWith('#[doc = "')) && !foundDocComment) {
             foundDocComment = true;
             docCommentStart = i;
@@ -24,39 +23,33 @@ async function handleDocAttribute(document: vscode.TextDocument, position: vscod
             inMultiLineDocComment = false;
         }
 
-        // Handling for single-line doc comments
-        if (line.startsWith('#![doc(') && !foundDocComment) {
-            foundDocComment = true;
-            docCommentStart = i;
-        }
-
-        if (!inFunction && !inMultiLineDocComment) {
+        // Handle function start
+        if (!foundDocComment && !inMultiLineDocComment) {
             const match = line.match(/(async\s+)?fn\s+(\w+)\s*\(/);
             if (match) {
-                functionStart = i;
                 functionName = match[2];
-                inFunction = true;
-            }
-        }
-
-        if ((foundDocComment && !inMultiLineDocComment) || inFunction) {
-            break;
-        }
-    }
-
-    if (foundDocComment && docCommentStart !== null && !functionName) {
-        for (let i = docCommentStart + 1; i < document.lineCount; i++) {
-            const line = document.lineAt(i).text.trim();
-
-            const match = line.match(/(async\s+)?fn\s+(\w+)\s*\(/);
-            if (match) {
                 functionStart = i;
-                functionName = match[2];
                 break;
             }
         }
     }
 
+    // If a doc comment was found, scan downwards to find the associated function
+    if (foundDocComment && docCommentStart !== null) {
+        for (let i = docCommentStart + 1; i < document.lineCount; i++) {
+            const line = document.lineAt(i).text.trim();
+
+            const match = line.match(/(async\s+)?fn\s+(\w+)\s*\(/);
+            if (match) {
+                functionName = match[2];
+                functionStart = i;
+                break;
+            }
+        }
+    }
+
+    // Determine the end of the function
+    let braceCount = 0;
     if (functionStart !== null) {
         for (let i = functionStart; i < document.lineCount; i++) {
             const line = document.lineAt(i).text;
@@ -74,9 +67,9 @@ async function handleDocAttribute(document: vscode.TextDocument, position: vscod
         }
     }
 
-    const inDocComment = foundDocComment && docCommentStart !== null && position.line >= docCommentStart;
+    const inDocComment = foundDocComment && docCommentStart !== null && position.line >= docCommentStart && (!functionStart || position.line <= functionStart);
     const inFunctionBody = functionStart !== null && functionEnd !== null && position.line >= functionStart && position.line <= functionEnd;
-    const isValid = inDocComment || inFunctionBody;
+    const isValid = inDocComment && !inFunctionBody;
 
     return isValid ? { isValid, fnName: functionName } : null;
 }

--- a/src/handle_doc_test.ts
+++ b/src/handle_doc_test.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode';
+
+async function handleDocTest(document: vscode.TextDocument, position: vscode.Position): Promise<{ isValid: boolean, fnName: string | null }> {
+    let foundDocTest = false;
+    let hasCodeBlock = false;
+    let functionName: string | null = null;
+
+    // Scan for `///` comment blocks and check for code blocks
+    for (let i = position.line; i >= 0; i--) {
+        const line = document.lineAt(i).text.trim();
+
+        if (line.startsWith('///')) {
+            foundDocTest = true;
+            if (line.includes('```')) {
+                hasCodeBlock = !hasCodeBlock;  // Toggle the presence of a code block
+            }
+        } else if (foundDocTest) {
+            break; // Exit loop once we're past the comment block
+        }
+    }
+
+    // If a valid doc-test is found, find the nearest function
+    if (foundDocTest && hasCodeBlock) {
+        for (let i = position.line + 1; i < document.lineCount; i++) {
+            const line = document.lineAt(i).text.trim();
+            const fnMatch = line.match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/);
+
+            if (fnMatch && !fnMatch[3].startsWith('test_')) {
+                functionName = fnMatch[3];
+                break;
+            }
+        }
+    }
+
+    const isValid = foundDocTest && hasCodeBlock && functionName !== null;
+
+    return { isValid, fnName: functionName };
+}
+
+export default handleDocTest;

--- a/src/handle_multiline_docs.ts
+++ b/src/handle_multiline_docs.ts
@@ -4,27 +4,21 @@ async function handleOptimizedDocTest(document: vscode.TextDocument, position: v
     let currentLineText = document.lineAt(position.line).text.trim();
 
     // Immediate return cases
-    // Done check
     if (currentLineText.startsWith('///') || currentLineText.startsWith('#[doc') || currentLineText.startsWith('#![doc')) {
         return { isValid: false, fnName: null };
     }
 
     // Check if current line is a function declaration
-    // Done check
     let fnMatch = currentLineText.match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/);
     if (fnMatch) {
         return scanUpwardsForDocStartAndBackticks(document, position);
     }
 
-
     // Scenarios based on doc comment start or end
-    // Done check
     if (currentLineText.startsWith('/**')) {
         return scanDownwardsForBackticksAndFunction(document, position);
     }
 
-
-    // Done Check
     if (currentLineText.startsWith('*/')) {
         return scanForFunctionAndUpwardsForBackticks(document, position);
     }
@@ -129,19 +123,16 @@ function exhaustiveSearchForDocTest(document: vscode.TextDocument, position: vsc
         // Check for start of doc comment or code block
         if (line.startsWith('/**')) {
             inDocCommentBlock = true;
+            break;
         }
         if (line.includes('```')) {
             codeBlockCount++;
         }
 
-        // Break if both doc comment and code block found
-        if (inDocCommentBlock && codeBlockCount > 0) {
-            break;
-        }
     }
 
     // Proceed only if both doc comment and code block are found
-    if (inDocCommentBlock && codeBlockCount > 0) {
+    if (inDocCommentBlock) {
         // Scan downwards for the function name
         for (let i = position.line; i < document.lineCount; i++) {
             const line = document.lineAt(i).text.trim();

--- a/src/handle_multiline_docs.ts
+++ b/src/handle_multiline_docs.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-async function handleOptimizedDocTest(document: vscode.TextDocument, position: vscode.Position): Promise<{ isValid: boolean, fnName: string | null }> {
+async function handleMultilineDocTest(document: vscode.TextDocument, position: vscode.Position): Promise<{ isValid: boolean, fnName: string | null }> {
     let currentLineText = document.lineAt(position.line).text.trim();
 
     // Immediate return cases
@@ -151,4 +151,4 @@ function exhaustiveSearchForDocTest(document: vscode.TextDocument, position: vsc
 
 
 
-export default handleOptimizedDocTest;
+export default handleMultilineDocTest;

--- a/src/handle_multiline_docs.ts
+++ b/src/handle_multiline_docs.ts
@@ -3,24 +3,31 @@ import * as vscode from 'vscode';
 async function handleOptimizedDocTest(document: vscode.TextDocument, position: vscode.Position): Promise<{ isValid: boolean, fnName: string | null }> {
     let currentLineText = document.lineAt(position.line).text.trim();
 
-    // // Immediate return cases
-    // if (currentLineText.startsWith('///') || currentLineText.startsWith('#[doc') || currentLineText.startsWith('#![doc')) {
-    //     return { isValid: false, fnName: null };
-    // }
+    // Immediate return cases
+    // Done check
+    if (currentLineText.startsWith('///') || currentLineText.startsWith('#[doc') || currentLineText.startsWith('#![doc')) {
+        return { isValid: false, fnName: null };
+    }
 
-    // // Check if current line is a function declaration
-    // let fnMatch = currentLineText.match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/);
-    // if (fnMatch) {
-    //     return scanUpwardsForDocStartAndBackticks(document, position);
-    // }
+    // Check if current line is a function declaration
+    // Done check
+    let fnMatch = currentLineText.match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/);
+    if (fnMatch) {
+        return scanUpwardsForDocStartAndBackticks(document, position);
+    }
 
-    // // Scenarios based on doc comment start or end
-    // if (currentLineText.startsWith('/**')) {
-    //     return scanDownwardsForBackticksAndFunction(document, position);
-    // }
-    // if (currentLineText.startsWith('*/')) {
-    //     return scanForFunctionAndUpwardsForBackticks(document, position);
-    // }
+
+    // Scenarios based on doc comment start or end
+    // Done check
+    if (currentLineText.startsWith('/**')) {
+        return scanDownwardsForBackticksAndFunction(document, position);
+    }
+
+
+    // Done Check
+    if (currentLineText.startsWith('*/')) {
+        return scanForFunctionAndUpwardsForBackticks(document, position);
+    }
 
     // Exhaustive search for other cases
     return exhaustiveSearchForDocTest(document, position);
@@ -29,7 +36,12 @@ async function handleOptimizedDocTest(document: vscode.TextDocument, position: v
 function scanUpwardsForDocStartAndBackticks(document: vscode.TextDocument, position: vscode.Position): { isValid: boolean, fnName: string | null } {
     let inDocCommentBlock = false;
     let inCodeBlock = false;
-    let functionName = document.lineAt(position.line).text.match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/)?.[3] || null;
+    console.log("debugger start")
+
+    console.log(document.lineAt(position.line).text)
+
+    console.log("debugger end")
+    let functionName = document.lineAt(position.line).text.trim().match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/)?.[3] || null;
 
     for (let i = position.line; i >= 0; i--) {
         const line = document.lineAt(i).text.trim();
@@ -60,12 +72,8 @@ function scanDownwardsForBackticksAndFunction(document: vscode.TextDocument, pos
         }
 
         if (line.includes('*/')) {
-            break;
-        }
-
-        const fnMatch = line.match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/);
-        if (fnMatch && inCodeBlock) {
-            functionName = fnMatch[3];
+            // Extract function name after the doc comment block ends
+            functionName = document.lineAt(i + 1).text.trim().match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/)?.[3] || null;
             break;
         }
     }
@@ -87,6 +95,7 @@ function scanForFunctionAndUpwardsForBackticks(document: vscode.TextDocument, po
             functionName = fnMatch[3];
             break;
         }
+
     }
 
     // Scanning upwards for backticks

--- a/src/handle_multiline_docs.ts
+++ b/src/handle_multiline_docs.ts
@@ -1,0 +1,158 @@
+import * as vscode from 'vscode';
+
+async function handleOptimizedDocTest(document: vscode.TextDocument, position: vscode.Position): Promise<{ isValid: boolean, fnName: string | null }> {
+    let currentLineText = document.lineAt(position.line).text.trim();
+
+    // // Immediate return cases
+    // if (currentLineText.startsWith('///') || currentLineText.startsWith('#[doc') || currentLineText.startsWith('#![doc')) {
+    //     return { isValid: false, fnName: null };
+    // }
+
+    // // Check if current line is a function declaration
+    // let fnMatch = currentLineText.match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/);
+    // if (fnMatch) {
+    //     return scanUpwardsForDocStartAndBackticks(document, position);
+    // }
+
+    // // Scenarios based on doc comment start or end
+    // if (currentLineText.startsWith('/**')) {
+    //     return scanDownwardsForBackticksAndFunction(document, position);
+    // }
+    // if (currentLineText.startsWith('*/')) {
+    //     return scanForFunctionAndUpwardsForBackticks(document, position);
+    // }
+
+    // Exhaustive search for other cases
+    return exhaustiveSearchForDocTest(document, position);
+}
+
+function scanUpwardsForDocStartAndBackticks(document: vscode.TextDocument, position: vscode.Position): { isValid: boolean, fnName: string | null } {
+    let inDocCommentBlock = false;
+    let inCodeBlock = false;
+    let functionName = document.lineAt(position.line).text.match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/)?.[3] || null;
+
+    for (let i = position.line; i >= 0; i--) {
+        const line = document.lineAt(i).text.trim();
+
+        if (line.startsWith('/**')) {
+            inDocCommentBlock = true;
+            break;
+        }
+
+        if (line.includes('```')) {
+            inCodeBlock = true;
+        }
+    }
+
+    return { isValid: inDocCommentBlock && inCodeBlock, fnName: functionName };
+}
+
+
+function scanDownwardsForBackticksAndFunction(document: vscode.TextDocument, position: vscode.Position): { isValid: boolean, fnName: string | null } {
+    let inCodeBlock = false;
+    let functionName: string | null = null;
+
+    for (let i = position.line; i < document.lineCount; i++) {
+        const line = document.lineAt(i).text.trim();
+
+        if (line.includes('```')) {
+            inCodeBlock = true;
+        }
+
+        if (line.includes('*/')) {
+            break;
+        }
+
+        const fnMatch = line.match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/);
+        if (fnMatch && inCodeBlock) {
+            functionName = fnMatch[3];
+            break;
+        }
+    }
+
+    return { isValid: inCodeBlock, fnName: functionName };
+}
+
+
+function scanForFunctionAndUpwardsForBackticks(document: vscode.TextDocument, position: vscode.Position): { isValid: boolean, fnName: string | null } {
+    let inCodeBlock = false;
+    let functionName: string | null = null;
+
+    // Scanning downwards for the function
+    for (let i = position.line; i < document.lineCount; i++) {
+        const line = document.lineAt(i).text.trim();
+        const fnMatch = line.match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/);
+
+        if (fnMatch) {
+            functionName = fnMatch[3];
+            break;
+        }
+    }
+
+    // Scanning upwards for backticks
+    for (let i = position.line; i >= 0 && functionName; i--) {
+        const line = document.lineAt(i).text.trim();
+        if (line.includes('```')) {
+            inCodeBlock = true;
+            break;
+        }
+    }
+
+    return { isValid: inCodeBlock && functionName !== null, fnName: functionName };
+}
+
+
+function exhaustiveSearchForDocTest(document: vscode.TextDocument, position: vscode.Position): { isValid: boolean, fnName: string | null } {
+    let inDocCommentBlock = false;
+    let inCodeBlock = false;
+    let functionName: string | null = null;
+    let codeBlockCount = 0;
+
+    // Scan upwards for the start of the doc comment and a code block
+    for (let i = position.line; i >= 0; i--) {
+        const line = document.lineAt(i).text.trim();
+
+        if (line.startsWith('/**')) {
+            inDocCommentBlock = true;
+        }
+
+        if (line.includes('```')) {
+            codeBlockCount++;
+        }
+
+        if (inDocCommentBlock && codeBlockCount > 0) {
+            // Found both the doc comment and a code block
+            break;
+        }
+    }
+
+    // If both doc comment and code block are not found, return false
+    if (!inDocCommentBlock || codeBlockCount === 0) {
+        return { isValid: false, fnName: null };
+    }
+
+    // Scan downwards for the function name, ensuring we're past the code block and comment end
+    let pastCodeBlock = false;
+    for (let i = position.line; i < document.lineCount; i++) {
+        const line = document.lineAt(i).text.trim();
+
+        if (line.includes('```')) {
+            pastCodeBlock = !pastCodeBlock;
+        }
+
+        if (line.includes('*/')) {
+            pastCodeBlock = false;  // Ensure we are past the closing comment tag
+        }
+
+        const fnMatch = line.match(/^(pub\s+)?(async\s+)?fn\s+(\w+)/);
+        if (fnMatch && !pastCodeBlock) {
+            functionName = fnMatch[3];
+            break;
+        }
+    }
+
+    return { isValid: functionName !== null, fnName: functionName };
+}
+
+
+export default handleOptimizedDocTest;

--- a/src/is_doctest.ts
+++ b/src/is_doctest.ts
@@ -14,52 +14,65 @@ async function isDocTest(filePath: string, position: vscode.Position | undefined
     let braceCount = 0;
     let inFunction = false;
     let functionName: string | null = null;
+    let inMultiLineDocComment = false;
 
     console.log(`Starting scan from position: ${position.line}`);
 
-    // Scan upwards to find the start of the doc comment
     for (let i = position.line; i >= 0; i--) {
         const line = document.lineAt(i).text.trim();
         console.log(`Checking line ${i}: ${line}`);
 
-        // Check for doc comment (///)
-        if (line.startsWith('///') && !foundDocComment) {
+        // Check for start of multiline doc comment
+        if ((line.startsWith('#[doc = r#"') || line.startsWith('#[doc = "')) && !foundDocComment) {
             foundDocComment = true;
             docCommentStart = i;
-            console.log(`Doc comment found starting at line ${i}`);
+            inMultiLineDocComment = true;
         }
 
-        // Once a doc comment is found, stop the upward scan
-        if (foundDocComment) {
-            console.log(`Stopping upward scan at line ${i}`);
-            break;
+        // Check for end of multiline doc comment
+        if (inMultiLineDocComment && line.endsWith('"#]')) {
+            inMultiLineDocComment = false;
         }
-    }
 
-    // If doc comment start was found, scan downwards to find the associated function
-    if (foundDocComment && docCommentStart !== null) {
-        console.log(`Scanning downwards from doc comment start at line ${docCommentStart}`);
-        for (let i = docCommentStart + 1; i < document.lineCount; i++) {
-            const line = document.lineAt(i).text.trim();
-            console.log(`Checking line ${i}: ${line}`);
+        // Check for single-line doc comment
+        if (line.startsWith('#![doc(') && !foundDocComment) {
+            foundDocComment = true;
+            docCommentStart = i;
+        }
 
-            // Check for function start
+        // Check for function start
+        if (!inFunction && !inMultiLineDocComment) {
             const match = line.match(/(async\s+)?fn\s+(\w+)\s*\(/);
             if (match) {
                 functionStart = i;
                 functionName = match[2];
                 inFunction = true;
-                console.log(`Function '${functionName}' start found at line ${i}`);
+            }
+        }
+
+        // Once a doc comment or a function is found, stop the upward scan
+        if ((foundDocComment && !inMultiLineDocComment) || inFunction) {
+            break;
+        }
+    }
+
+    // If a doc comment was found, scan downwards to find the associated function
+    if (foundDocComment && docCommentStart !== null && !functionName) {
+        for (let i = docCommentStart + 1; i < document.lineCount; i++) {
+            const line = document.lineAt(i).text.trim();
+
+            const match = line.match(/(async\s+)?fn\s+(\w+)\s*\(/);
+            if (match) {
+                functionStart = i;
+                functionName = match[2];
                 break;
             }
         }
     }
 
-    // If function start was found, scan downwards to find function end
     if (functionStart !== null) {
         for (let i = functionStart; i < document.lineCount; i++) {
             const line = document.lineAt(i).text;
-            console.log(`Checking line ${i}: ${line}`);
 
             if (line.includes('{')) {
                 braceCount++;
@@ -68,25 +81,17 @@ async function isDocTest(filePath: string, position: vscode.Position | undefined
                 braceCount--;
                 if (braceCount === 0) {
                     functionEnd = i;
-                    console.log(`Function '${functionName}' end found at line ${i}`);
                     break;
                 }
             }
         }
     }
 
-    // Check if position is within the bounds of the function or doc comment
-    const inDocComment = foundDocComment && docCommentStart !== null && position.line <= docCommentStart;
+    const inDocComment = foundDocComment && docCommentStart !== null && position.line >= docCommentStart;
     const inFunctionBody = functionStart !== null && functionEnd !== null && position.line >= functionStart && position.line <= functionEnd;
     const isValid = inDocComment || inFunctionBody;
 
-    // If the line is after the function's end or if functionEnd is null, it's not valid and not part of the function
-    if (functionEnd !== null && position.line > functionEnd) {
-        return { isValid: false, fnName: null };
-    }
-
-    console.log(`Position ${position.line} is in doc comment: ${inDocComment}, in function body: ${inFunctionBody}, isValid: ${isValid}, functionName: ${functionName}`);
-    return { isValid, fnName: functionName };
+    return { isValid, fnName: isValid ? functionName : null };
 }
 
 export default isDocTest;

--- a/src/is_doctest.ts
+++ b/src/is_doctest.ts
@@ -14,9 +14,12 @@ async function isDocTest(filePath: string, position: vscode.Position | undefined
     let braceCount = 0;
     let inFunction = false;
 
+    console.log(`Starting scan from position: ${position.line}`);
+
     // Scan upwards to find the start of the doc comment or function
     for (let i = position.line; i >= 0; i--) {
         const line = document.lineAt(i).text.trim();
+        console.log(`Checking line ${i}: ${line}`);
 
         // Check for function start
         if (!inFunction) {
@@ -24,6 +27,7 @@ async function isDocTest(filePath: string, position: vscode.Position | undefined
             if (match) {
                 functionStart = i;
                 inFunction = true;
+                console.log(`Function start found at line ${i}`);
             }
         }
 
@@ -31,10 +35,12 @@ async function isDocTest(filePath: string, position: vscode.Position | undefined
         if (line.startsWith('///') && !foundDocComment) {
             foundDocComment = true;
             docCommentStart = i;
+            console.log(`Doc comment found starting at line ${i}`);
         }
 
         // Once a function or a doc comment is found, stop the upward scan
         if (foundDocComment || inFunction) {
+            console.log(`Stopping upward scan at line ${i}`);
             break;
         }
     }
@@ -46,8 +52,10 @@ async function isDocTest(filePath: string, position: vscode.Position | undefined
 
     // If function start was found, scan downwards to find function end
     if (functionStart !== null) {
+        console.log(`Scanning downwards from function start at line ${functionStart}`);
         for (let i = functionStart; i < document.lineCount; i++) {
             const line = document.lineAt(i).text;
+            console.log(`Checking line ${i}: ${line}`);
 
             if (line.includes('{')) {
                 braceCount++;
@@ -56,6 +64,7 @@ async function isDocTest(filePath: string, position: vscode.Position | undefined
                 braceCount--;
                 if (braceCount === 0) {
                     functionEnd = i;
+                    console.log(`Function end found at line ${i}`);
                     break;
                 }
             }
@@ -66,6 +75,7 @@ async function isDocTest(filePath: string, position: vscode.Position | undefined
     const inDocComment = foundDocComment && docCommentStart !== null && position.line <= docCommentStart;
     const inFunctionBody = functionStart !== null && functionEnd !== null && position.line >= functionStart && position.line <= functionEnd;
 
+    console.log(`Position ${position.line} is in doc comment: ${inDocComment}, in function body: ${inFunctionBody}`);
     return inDocComment || inFunctionBody;
 }
 

--- a/src/is_doctest.ts
+++ b/src/is_doctest.ts
@@ -33,8 +33,8 @@ async function isDocTest(filePath: string, position: vscode.Position | undefined
             }
         }
 
-        // Check for doc comment
-        if (line.startsWith('///') && !foundDocComment) {
+        // Check for doc comment (both /// and /** */)
+        if ((line.startsWith('///') || line.startsWith('/**')) && !foundDocComment) {
             foundDocComment = true;
             docCommentStart = i;
             console.log(`Doc comment found starting at line ${i}`);
@@ -79,7 +79,7 @@ async function isDocTest(filePath: string, position: vscode.Position | undefined
     const isValid = inDocComment || inFunctionBody;
 
     console.log(`Position ${position.line} is in doc comment: ${inDocComment}, in function body: ${inFunctionBody}, isValid: ${isValid}, functionName: ${functionName}`);
-    return { isValid, fnName: functionName };
+    return { isValid, fnName: inFunctionBody ? functionName : null };
 }
 
 export default isDocTest;

--- a/src/is_doctest.ts
+++ b/src/is_doctest.ts
@@ -17,44 +17,46 @@ async function isDocTest(filePath: string, position: vscode.Position | undefined
 
     console.log(`Starting scan from position: ${position.line}`);
 
-    // Scan upwards to find the start of the doc comment or function
+    // Scan upwards to find the start of the doc comment
     for (let i = position.line; i >= 0; i--) {
         const line = document.lineAt(i).text.trim();
         console.log(`Checking line ${i}: ${line}`);
 
-        // Check for function start
-        if (!inFunction) {
+        // Check for doc comment (///)
+        if (line.startsWith('///') && !foundDocComment) {
+            foundDocComment = true;
+            docCommentStart = i;
+            console.log(`Doc comment found starting at line ${i}`);
+        }
+
+        // Once a doc comment is found, stop the upward scan
+        if (foundDocComment) {
+            console.log(`Stopping upward scan at line ${i}`);
+            break;
+        }
+    }
+
+    // If doc comment start was found, scan downwards to find the associated function
+    if (foundDocComment && docCommentStart !== null) {
+        console.log(`Scanning downwards from doc comment start at line ${docCommentStart}`);
+        for (let i = docCommentStart + 1; i < document.lineCount; i++) {
+            const line = document.lineAt(i).text.trim();
+            console.log(`Checking line ${i}: ${line}`);
+
+            // Check for function start
             const match = line.match(/(async\s+)?fn\s+(\w+)\s*\(/);
             if (match) {
                 functionStart = i;
                 functionName = match[2];
                 inFunction = true;
                 console.log(`Function '${functionName}' start found at line ${i}`);
+                break;
             }
         }
-
-        // Check for doc comment (both /// and /** */)
-        if ((line.startsWith('///') || line.startsWith('/**')) && !foundDocComment) {
-            foundDocComment = true;
-            docCommentStart = i;
-            console.log(`Doc comment found starting at line ${i}`);
-        }
-
-        // Once a function or a doc comment is found, stop the upward scan
-        if (foundDocComment || inFunction) {
-            console.log(`Stopping upward scan at line ${i}`);
-            break;
-        }
-    }
-
-    if (functionStart === null && !foundDocComment) {
-        console.log("No function or doc comment found.");
-        return { isValid: false, fnName: null };
     }
 
     // If function start was found, scan downwards to find function end
     if (functionStart !== null) {
-        console.log(`Scanning downwards from function start at line ${functionStart}`);
         for (let i = functionStart; i < document.lineCount; i++) {
             const line = document.lineAt(i).text;
             console.log(`Checking line ${i}: ${line}`);
@@ -78,8 +80,13 @@ async function isDocTest(filePath: string, position: vscode.Position | undefined
     const inFunctionBody = functionStart !== null && functionEnd !== null && position.line >= functionStart && position.line <= functionEnd;
     const isValid = inDocComment || inFunctionBody;
 
+    // If the line is after the function's end or if functionEnd is null, it's not valid and not part of the function
+    if (functionEnd !== null && position.line > functionEnd) {
+        return { isValid: false, fnName: null };
+    }
+
     console.log(`Position ${position.line} is in doc comment: ${inDocComment}, in function body: ${inFunctionBody}, isValid: ${isValid}, functionName: ${functionName}`);
-    return { isValid, fnName: inFunctionBody ? functionName : null };
+    return { isValid, fnName: functionName };
 }
 
 export default isDocTest;

--- a/src/is_doctest.ts
+++ b/src/is_doctest.ts
@@ -1,0 +1,72 @@
+import * as vscode from 'vscode';
+
+async function isDocTest(filePath: string, position: vscode.Position | undefined): Promise<boolean> {
+    if (!position) {
+        console.log("Position is undefined.");
+        return false;
+    }
+    const document = await vscode.workspace.openTextDocument(filePath);
+
+    let foundDocComment = false;
+    let docCommentStart: number | null = null;
+    let functionStart: number | null = null;
+    let functionEnd: number | null = null;
+    let braceCount = 0;
+    let inFunction = false;
+
+    // Scan upwards to find the start of the doc comment or function
+    for (let i = position.line; i >= 0; i--) {
+        const line = document.lineAt(i).text.trim();
+
+        // Check for function start
+        if (!inFunction) {
+            const match = line.match(/(async\s+)?fn\s+(\w+)\s*\(/);
+            if (match) {
+                functionStart = i;
+                inFunction = true;
+            }
+        }
+
+        // Check for doc comment
+        if (line.startsWith('///') && !foundDocComment) {
+            foundDocComment = true;
+            docCommentStart = i;
+        }
+
+        // Once a function or a doc comment is found, stop the upward scan
+        if (foundDocComment || inFunction) {
+            break;
+        }
+    }
+
+    if (functionStart === null && !foundDocComment) {
+        console.log("No function or doc comment found.");
+        return false;
+    }
+
+    // If function start was found, scan downwards to find function end
+    if (functionStart !== null) {
+        for (let i = functionStart; i < document.lineCount; i++) {
+            const line = document.lineAt(i).text;
+
+            if (line.includes('{')) {
+                braceCount++;
+            }
+            if (line.includes('}')) {
+                braceCount--;
+                if (braceCount === 0) {
+                    functionEnd = i;
+                    break;
+                }
+            }
+        }
+    }
+
+    // Check if position is within the bounds of the function or doc comment
+    const inDocComment = foundDocComment && docCommentStart !== null && position.line <= docCommentStart;
+    const inFunctionBody = functionStart !== null && functionEnd !== null && position.line >= functionStart && position.line <= functionEnd;
+
+    return inDocComment || inFunctionBody;
+}
+
+export default isDocTest;

--- a/src/parse_multi_block_comments.ts
+++ b/src/parse_multi_block_comments.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+
+function parseMultiBlocksComment(document: vscode.TextDocument, line: number): { start: number, end: number } | null {
+    let start = line;
+    let end = line;
+    let foundStart = false;
+
+    // Scan upwards for the start of the block comment
+    for (let i = line; i >= 0; i--) {
+        if (document.lineAt(i).text.trim().startsWith('/**')) {
+            start = i;
+            foundStart = true;
+            break;
+        }
+    }
+
+    // If start is found, scan downwards for the end of the block comment
+    if (foundStart) {
+        for (let i = line; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.trim().endsWith('*/')) {
+                end = i;
+                return { start, end };
+            }
+        }
+    }
+
+    return null;
+}
+
+export default parseMultiBlocksComment;


### PR DESCRIPTION
Quickly Run Doc Test , Under cursor

- Able to Parse #[doc] and #![doc]
- Able to Parse /// with ` code block`
- Able to Parse /** with `code block` */