### PR TITLE
override arguments on chosen context using .cargo_runner.toml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the "cargo-runner" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+## 1.1.9
+- Ability to override arguments with CMD+SHIFT+R
+- Add ability to remove override arguments by entering an empty string
+- Pressing CMD+R would add the override arguments
+- an artifact is created when adding arguments , a file called `.cargo_runner.toml`
 ## 1.1.8
 - fix nextest commands
 ## 1.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the "cargo-runner" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+## 1.2.0
+- Ability to override arguments with CMD+SHIFT+R
+- Add ability to remove override arguments by entering an empty string
+- Pressing CMD+R would add the override arguments
+- an artifact is created when adding arguments , a file called `.cargo_runner.toml`
 ## 1.1.9
 - Ability to override arguments with CMD+SHIFT+R
 - Add ability to remove override arguments by entering an empty string

--- a/README.md
+++ b/README.md
@@ -16,7 +16,39 @@ Cargo Runner is a powerful and intuitive tool designed to streamline the develop
 - **Real-Time Feedback**: Immediate visual feedback on the status of build and test processes, helping you identify and fix issues more quickly.
 - **Customizable Environment**: Tailor Cargo Runner to your workflow with customizable settings and keybindings.
 
+- **Override Arguments** : Quickly Override Command Arguments on different context such as: `run` , `build`, `test`, `doctest` and `bench` 
+
 ## Demo Screenshot
+
+### Override Arguments
+
+> Adding Arguments
+1. Press <kbd>CMD</kbd>+<kbd>SHIFT</kbd>+<kbd>R</kbd>
+2. Choose context from any of the following options:
+    - run
+    - build
+    - test
+    - doctest
+    - bench
+3. Type those parameters you wanna add to override the default 
+e.g. 
+
+```sh
+--jobs 5 --all-features
+```
+> Removing Arguments
+1. Press <kbd>CMD</kbd>+<kbd>SHIFT</kbd>+<kbd>R</kbd>
+
+2. Choose context from any of the following options:
+    - run
+    - build
+    - test
+    - doctest
+    - bench
+3. Press Enter (dont type anything)
+
+This would remove the parameters `--jobs 5 --all-features` on .`cargo_runner.toml` file
+
 
 ### Cargo Run 
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/codeitlikemiley/cargo-runner"
   },
-"version": "1.1.8",
+  "version": "1.1.9",
   "engines": {
     "vscode": "^1.85.0"
   },
@@ -22,6 +22,10 @@
       {
         "command": "cargo-runner.exec",
         "title": "Cargo Runner"
+      },
+      {
+        "command": "cargo-runner.addArgs",
+        "title": "Add Cargo Runner Args"
       }
     ],
     "keybindings": [
@@ -30,6 +34,12 @@
         "key": "ctrl+r",
         "mac": "cmd+r",
         "when": "resourceFilename =~ /\\.(rs)$/ && editorTextFocus && editorLangId == rust && editorHasDefinitionProvider"
+      },
+      {
+        "command": "cargo-runner.addArgs",
+        "key": "ctrl+shift+r",
+        "mac": "cmd+shift+r",
+        "when": "editorTextFocus && editorLangId == rust"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/codeitlikemiley/cargo-runner"
   },
-  "version": "1.1.9",
+  "version": "1.2.0",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/src/add_args_to_toml.ts
+++ b/src/add_args_to_toml.ts
@@ -1,0 +1,35 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as toml from '@iarna/toml';
+
+export default async function addArgsToToml(args: Array<{name: string, type: "int" | "boolean" | "string", value: any}>, context: string) {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        vscode.window.showErrorMessage('No active editor found.');
+        return;
+    }
+
+    let tomlPath = path.join(path.dirname(editor.document.uri.fsPath), '.cargo_runner.toml');
+    
+    let config: any;
+    if (fs.existsSync(tomlPath)) {
+        const tomlContent = fs.readFileSync(tomlPath, 'utf-8');
+        config = toml.parse(tomlContent);
+    } else {
+        config = {};
+    }
+
+    if (args.length === 0) {
+        // If no arguments are provided, remove the selected context from the TOML
+        delete config[context];
+        vscode.window.showInformationMessage(`Context '${context}' removed from .cargo_runner.toml.`);
+    } else {
+        // Replace existing args for the context with the new ones
+        config[context] = args;
+        vscode.window.showInformationMessage(`Arguments for context '${context}' updated in .cargo_runner.toml.`);
+    }
+
+    // Write the (updated or reduced) config back to .cargo_runner.toml
+    fs.writeFileSync(tomlPath, toml.stringify(config));
+}

--- a/src/build_args.ts
+++ b/src/build_args.ts
@@ -1,0 +1,13 @@
+import { CommandArg } from "./cargo_runner_args_type";
+
+export default function buildArgs(contextArgs: Array<CommandArg>): string {
+    return contextArgs.map(arg => {
+        if (arg.type === "boolean" && arg.value === true) {
+            // For boolean type args, if the value is true, just add the name (flag style)
+            return `--${arg.name}`;
+        } else {
+            // For int and string types, add name=value
+            return `--${arg.name}=${arg.value}`;
+        }
+    }).join(' ');
+}

--- a/src/cargo_runner_args_type.ts
+++ b/src/cargo_runner_args_type.ts
@@ -1,0 +1,17 @@
+
+export interface CommandArg {
+    name: string;
+    type: "string" | "int" | "boolean";
+    value: string | number | boolean;
+}
+
+export interface CargoRunnerToml {
+    run?: Array<CommandArg>;
+    test?: Array<CommandArg>;
+    build?: Array<CommandArg>;
+    doctest?: Array<CommandArg>;
+    bench?: Array<CommandArg>;
+}
+
+    
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import exec from './exec';
 import { isRustScript, runRustScript } from './rust_file_script';
+import parseUserInput from './parseUserInput';
+import addArgsToToml from './add_args_to_toml';
 
 export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.exec', async () => {
@@ -33,4 +35,45 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.window.showInformationMessage('Cannot run.');
 		}
 	}));
+
+	context.subscriptions.push(vscode.commands.registerCommand('cargo-runner.addArgs', async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showErrorMessage('No active editor found.');
+            return;
+        }
+
+		// Choose what arguments we would override
+		// run, test, bench, doctest , build
+		let context: string|null |undefined = await vscode.window.showQuickPick(['run', 'test', 'bench', 'doctest', 'build'], {
+			placeHolder: 'Choose what arguments context you would like to override.'
+		}).then(async (context) => {
+			if (context) {
+				return context;
+			}
+		}
+		);
+
+		if (!context) {
+			vscode.window.showErrorMessage('No context selected.');
+			return;
+		}
+
+        // Open input box for user input
+        const userInput = await vscode.window.showInputBox({
+            prompt: 'Enter your args (e.g., "--count=5 --verbose --name=cargo-runner")',
+            ignoreFocusOut: true
+        });
+
+        if (!userInput || userInput.trim() === "" || userInput === undefined || userInput === null){
+			// we should delete the whole context if no args are provided
+			await addArgsToToml([], context);
+        }
+		
+
+        // Parse the input and add arguments to TOML
+        const argsToAdd = parseUserInput(userInput!);
+		await addArgsToToml(argsToAdd, context);
+		
+    }));
 }

--- a/src/get_args.ts
+++ b/src/get_args.ts
@@ -1,0 +1,18 @@
+import { parse } from "@iarna/toml";
+import * as fs from 'fs';
+import { CargoRunnerToml } from "./cargo_runner_args_type";
+
+export default async function getArgs(filePath: string | null): Promise<CargoRunnerToml | null> {
+    if (filePath === null || filePath === '') {
+        return null;
+    }
+    try {
+        const cargoTomlContent = fs.readFileSync(filePath, 'utf-8');
+        const cargo = parse(cargoTomlContent) as CargoRunnerToml;
+        console.log('Parsed Cargo Runner TOML:', cargo);
+        return cargo;
+    } catch (error) {
+        console.error('Failed to read or parse the Cargo Runner TOML file:', error);
+        return null;
+    }
+};

--- a/src/get_cargo_runner_args_config.ts
+++ b/src/get_cargo_runner_args_config.ts
@@ -1,0 +1,17 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export default function findCargoRunnerArgsToml(filePath: string) : string | null {
+    let currentDir = path.dirname(filePath);
+    const workspaceRoot = vscode.workspace.rootPath || process.cwd();
+    let tomlPath = path.join(currentDir, '.cargo_runner.toml');
+    while (!fs.existsSync(tomlPath)) {
+        if (currentDir === workspaceRoot) {
+            return null;
+        }
+        currentDir = path.dirname(currentDir);
+        tomlPath = path.join(currentDir, '.cargo_runner.toml');
+    }
+    return tomlPath;
+}

--- a/src/parseUserInput.ts
+++ b/src/parseUserInput.ts
@@ -1,0 +1,44 @@
+export default function parseUserInput(input: string): Array<{name: string, type: "string" | "int" | "boolean", value: any}> {
+    // First, split the input string into segments that are either standalone flags or key-value pairs.
+    const segments = input.match(/--?\w+(-\w+)*=?[^-\s"]*|"[^"]*"|\S+/g) || [];
+
+    // Initialize an array to hold the parsed arguments.
+    const args = [];
+
+    for (let i = 0; i < segments.length; i++) {
+        let segment = segments[i];
+        let name, value;
+
+        if (segment.startsWith('--')) {
+            // Handle long arguments.
+            [name, value] = segment.split('=', 2);
+
+            if (value === undefined && segments[i + 1] && !segments[i + 1].startsWith('-')) {
+                // Look ahead for the next segment as the value if it's not another argument.
+                value = segments[++i];
+            }
+        } else if (segment.startsWith('-')) {
+            // Handle short arguments.
+            name = segment;
+            if (segments[i + 1] && !segments[i + 1].startsWith('-')) {
+                value = segments[++i];
+            }
+        }
+
+        // Normalize argument names by removing leading dashes.
+        name = name!.replace(/^--?/, '');
+
+        // Determine the type and value.
+        if (value === undefined) {
+            args.push({ name, type: "boolean", value: true });
+        } else if (!isNaN(Number(value))) {
+            args.push({ name, type: "int", value: Number(value) });
+        } else {
+            // Remove surrounding quotes from string values, if any.
+            value = value.replace(/^"|"$/g, '');
+            args.push({ name, type: "string", value });
+        }
+    }
+
+    return args as Array<{ name: string, type: "string" | "boolean" | "int", value: any }>;
+}


### PR DESCRIPTION
This PR allows you to Add Arguments on the built in ones based on context

1. run context
2. build context
3. test context
4. doctest context
5. bench context

by default

when we press command + R
it generates command like : cargo run -p package_name --bin bin_name

lets say we want for a moment to override that

we just press command+shift + R , then choose the `run` context

then type those arguments you wanted e.g.

```sh
--num_agents=5 --use_submarine_base
```

depending on your project structure you can have one or more .cargo_runner.toml file
where those parameters are saved.

once saved, when we invoke command + R\
it should generate now

```sh
cargo run -p package_name --bin bin_name -- --num_agents=5 --use_submarine_base
```

How do we remove it?

we just press command+shift + R then choose the `run` context then we just enter an empty string. It should remove all the parameters for that specific `context